### PR TITLE
Add callbacks when message received, error occurs or connection closed

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,11 +20,17 @@ Example
 Please see the example in `examples/example.js`. Or here for reference:
 
 ```js
-var DDPClient = require("ddp"); 
+var DDPClient = require("ddp");
 
-var ddpclient = new DDPClient({host: "localhost", port: 3000});
+var ddpclient = new DDPClient({
+    host: "localhost", 
+    port: 3000,
+    /* optional: */
+    auto_reconnect: true,
+    auto_reconnect_timer: 500
+  });
 
-ddpclient.on('connect', function() {
+ddpclient.connect(function() {
   console.log('connected!');
   
   ddpclient.call('test-function', ['foo', 'bar'], function(err, result) {
@@ -37,25 +43,24 @@ ddpclient.on('connect', function() {
   })
 });
 
-ddpclient.on('close', function(code, message) {
-	console.log("Close: [%s] %s", code, message);
-	// Automatically reconnect
-	ddpclient.connect();
-});
-
-ddpclient.on('error', function(error) {
-	console.log("Error: %s", error);
-	// Reconnect after 1 sec.
-	setTimeout(function() { ddpclient.connect(); }, 1000);
-});
-
-// Useful for debugging
+/*
+ * Useful for debugging and learning the ddp protocol
+ */
 ddpclient.on('message', function(msg) {
 	console.log("ddp message: " + msg);
-	// You can also do cool stuff to the msg before it's processed.
 });	
 
-ddpclient.connect();
+/* 
+ * If you need to do something specific on close or errors.
+ * (You can also disable auto_reconnect and call ddpclient.connect()
+ *  when you are ready to re-connect.)
+*/
+ddpclient.on('socket-close', function(code, message) {
+  console.log("Close: %s %s", code, message);
+});
+ddpclient.on('socket-error', function(error) {
+  console.log("Error: %j", error);
+});
 ```
 
 Thanks

--- a/examples/example.js
+++ b/examples/example.js
@@ -1,9 +1,14 @@
-var DDPClient = require("../lib/ddp-client"); 
+var DDPClient = require("../lib/ddp-client");
 
-var ddpclient = new DDPClient({host: "localhost", port: 3000});
+var ddpclient = new DDPClient({
+    host: "localhost",
+    port: 3000,
+    /* optional: */
+    auto_reconnect: true,
+    auto_reconnect_timer: 500
+  });
 
-ddpclient.on('connect', function() {
-  
+ddpclient.connect(function() {
   console.log('connected!');
   
   ddpclient.call('test-function', ['foo', 'bar'], function(err, result) {
@@ -15,22 +20,22 @@ ddpclient.on('connect', function() {
     console.log(ddpclient.collections.posts);
   })
 });
-ddpclient.on('close', function(code, message) {
-	console.log("Close: [%s] %s", code, message);
-	// Automatically reconnect
-	ddpclient.connect();
-});
-ddpclient.on('error', function(error) {
-	console.log("Error: %s", error);
-	// Reconnect after 1 sec.
-	setTimeout(function() { ddpclient.connect(); }, 1000);
-});
 
-// Useful for debugging
+/*
+ * Useful for debugging and learning the ddp protocol
+ */
 ddpclient.on('message', function(msg) {
 	console.log("ddp message: " + msg);
-	// You can also do cool stuff to the msg before it's processed.
 });	
 
-/* Last but not least - Actually start the connection */
-ddpclient.connect();
+/* 
+ * If you need to do something specific on close or errors.
+ * You can also disable auto_reconnect and 
+ * call ddpclient.connect() when you are ready to re-connect.
+*/
+ddpclient.on('socket-close', function(code, message) {
+  console.log("Close: %s %s", code, message);
+});
+ddpclient.on('socket-error', function(error) {
+  console.log("Error: %j", error);
+});

--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -11,6 +11,8 @@ DDPClient = function(opts) {
   self.port = opts.port || 3000;
   self.path = opts.path || 'websocket';
   self.use_ssl = opts.use_ssl || self.port === 443;
+  self.auto_reconnect = ('auto_reconnect' in opts) ? opts.auto_reconnect : true;
+  self.auto_reconnect_timer = ('auto_reconnect_timer' in opts) ? opts.auto_reconnect_timer : 500;
 
   // very very simple collections (name -> [{id -> document}])
   self.collections = {};
@@ -34,11 +36,17 @@ DDPClient.prototype._prepareHandlers = function() {
   });
   
   self.socket.on('error', function(error) {
-    self.emit('error', error);
+    self.emit('socket-error', error);
+    if (self.auto_reconnect) {
+      setTimeout(function() { self.connect(); }, self.auto_reconnect_timer);
+    }
   });
 
   self.socket.on('close', function(code, message) {
-    self.emit('close', code, message);
+    self.emit('socket-close', code, message);
+    if (self.auto_reconnect) {
+      setTimeout(function() { self.connect(); }, self.auto_reconnect_timer);
+    }
   });
   
   self.socket.on('message', function(data, flags) {
@@ -146,7 +154,8 @@ DDPClient.prototype._updateCollection = function(data) {
 /* open the connection to the server
  * 
  *  connected(): Called when the 'connected' message is received
- *               Deprecated - use on('connected', cb) instead
+ *               If auto_reconnect is true (default), the callback will be 
+ *               called each time the connection is opened.
  */
 DDPClient.prototype.connect = function(connected) {
   var self = this;


### PR DESCRIPTION
I was not satisfied with the first solution and having multiple callbacks passed to connect() so I looked at `ws` and how they dealt with it. I have adopted the same pattern.

So I use `events.EventEmitter` and inherit from it. And then have different messages: `on('connected')`, `on('message')`, `on('close')` and `on('error')`. I believe this solution to be much better. I hope you will agree.

Cheers!
