### PR TITLE
Fix infinite loop when calling close when auto_reconnect is enabled

### DIFF
--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -58,7 +58,7 @@ DDPClient.prototype._prepareHandlers = function() {
 
   self.socket.on('close', function(code, message) {
     self.emit('socket-close', code, message);
-    if (self.auto_reconnect && ! self._connectionFailed) {
+    if (self.auto_reconnect && ! self._connectionFailed && ! self._isClosing) {
       setTimeout(function() { self.connect(); }, self.auto_reconnect_timer);
     }
   });
@@ -197,6 +197,7 @@ DDPClient.prototype._nextId = function() {
 DDPClient.prototype.connect = function(connected) {
   var self = this;
   self._connectionFailed = false;
+  self._isClosing = false;
 
   if (connected) {
     self.addListener("connected", connected);
@@ -214,7 +215,7 @@ DDPClient.prototype.connect = function(connected) {
 
 DDPClient.prototype.close = function() {
   var self = this;
-  self._connectionFailed = true;
+  self._isClosing = true;
   self.socket.close();
 };
 


### PR DESCRIPTION
For #16

Found it! When calling close it would attempt to reconnect since
`auto_reconnect` is set to true by default.
