### PR TITLE
Can pass maintain_collections option.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,7 +30,8 @@ var ddpclient = new DDPClient({
   auto_reconnect_timer: 500,
   use_ejson: true,  // default is false
   use_ssl: false, //connect to SSL server,
-  use_ssl_strict: true //Set to false if you have root ca trouble.
+  use_ssl_strict: true, //Set to false if you have root ca trouble.
+  maintain_collections: true //Set to false to maintain your own collections.
 });
 
 ddpclient.connect(function(error) {
@@ -97,3 +98,4 @@ Contributions:
  * Mason Gravitt (@emgee3)
  * Mike Bannister (@possiblities)
  * Chris Mather (@eventedmind)
+ * James Gill (@jagill)

--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -17,12 +17,14 @@ DDPClient = function(opts) {
   self.auto_reconnect = ('auto_reconnect' in opts) ? opts.auto_reconnect : true;
   self.auto_reconnect_timer = ('auto_reconnect_timer' in opts) ? opts.auto_reconnect_timer : 500;
   self.use_ssl_strict = ('use_ssl_strict' in opts) ? opts.use_ssl_strict : true;
+  self.maintain_collections = ('maintain_collections' in opts) ? opts.maintain_collections : true;
 
   // add support for EJSON, off by default to avoid breaking change
   self.use_ejson = opts.use_ejson || false;
 
   // very very simple collections (name -> [{id -> document}])
-  self.collections = {};
+  if (self.maintain_collections)
+    self.collections = {};
 
   // internal stuff to track callbacks
   self._next_id = 0;
@@ -143,7 +145,7 @@ DDPClient.prototype._message = function(data, flags) {
 
   // add document to collection
   } else if (data.msg === 'added') {
-    if (data.collection) {
+    if (self.maintain_collections && data.collection) {
       var name = data.collection, id = data.id;
 
       if (!self.collections[name])
@@ -160,7 +162,7 @@ DDPClient.prototype._message = function(data, flags) {
 
   // remove document from collection
   } else if (data.msg === 'removed') {
-    if (data.collection) {
+    if (self.maintain_collections && data.collection) {
       var name = data.collection, id = data.id;
 
       if (!self.collections[name][id])
@@ -171,7 +173,7 @@ DDPClient.prototype._message = function(data, flags) {
 
   // change document in collection
   } else if (data.msg === 'changed') {
-    if (data.collection) {
+    if (self.maintain_collections && data.collection) {
       var name = data.collection, id = data.id;
 
       if (!self.collections[name]) return;

--- a/test/ddp-client.js
+++ b/test/ddp-client.js
@@ -182,3 +182,31 @@ describe('EJSON', function() {
 
 });
 
+describe('maintain_collections', function() {
+  var DDPMessage = '{"msg":"added","collection":"posts","id":"2trpvcQ4pn32ZYXco","fields":{"text":"A cat was here"}}';
+
+  it('should maintain collections by default', function() {
+    var ddpclient = new DDPClient();
+    ddpclient._message(DDPMessage);
+    // ensure collections exist and are populated by add messages
+    assert.equal(ddpclient.collections.posts['2trpvcQ4pn32ZYXco'].text, "A cat was here");
+  });
+
+  it('should maintain collections if maintain_collections is true', function() {
+    var ddpclient = new DDPClient({ maintain_collections : true });
+    ddpclient._message(DDPMessage);
+    // ensure collections exist and are populated by add messages
+    assert.equal(ddpclient.collections.posts['2trpvcQ4pn32ZYXco'].text, "A cat was here");
+  });
+
+  it('should not maintain collections if maintain_collections is false',
+     function() {
+       var ddpclient = new DDPClient({ maintain_collections : false });
+       ddpclient._message(DDPMessage);
+       // ensure there are no collections
+       assert(!ddpclient.collections);
+
+     }
+  );
+
+});


### PR DESCRIPTION
If this is false, node-ddp-client does not maintain collections
(you will have to do this yourself).  Default is true.

Fixes #25.
