### PR TITLE
Only have at most one reconnect timer active.

### DIFF
--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -62,7 +62,6 @@ DDPClient.prototype._prepareHandlers = function() {
 
   self.socket.on('error', function(error) {
     self.emit('socket-error', error);
-    self._recoverNetworkError();
   });
 
   self.socket.on('close', function(event) {
@@ -77,10 +76,19 @@ DDPClient.prototype._prepareHandlers = function() {
   });
 };
 
+DDPClient.prototype._clearReconnectTimeout = function() {
+  var self = this;
+  if (self.reconnectTimeout) {
+    clearTimeout(self.reconnectTimeout);
+    self.reconnectTimeout = null;
+  }
+}
+
 DDPClient.prototype._recoverNetworkError = function() {
   var self = this;
   if (self.auto_reconnect && ! self._connectionFailed && ! self._isClosing) {
-    setTimeout(function() { self.connect(); }, self.auto_reconnect_timer);
+    self._clearReconnectTimeout();
+    self.reconnectTimeout = setTimeout(function() { self.connect(); }, self.auto_reconnect_timer);
   }
 };
 
@@ -227,7 +235,10 @@ DDPClient.prototype.connect = function(connected) {
   self._isClosing = false;
 
   if (connected) {
-    self.addListener("connected", connected);
+    self.addListener("connected", function() {
+      self._clearReconnectTimeout();
+      connected();
+    });
     self.addListener("failed", function(error) {
       self._connectionFailed = true;
       connected(error);

--- a/test/ddp-client.js
+++ b/test/ddp-client.js
@@ -56,7 +56,25 @@ describe('Automatic reconnection', function() {
     var ddpclient = new DDPClient({ auto_reconnect_timer: 10 });
 
     ddpclient.connect();
-    wsMock.emit('error', {});
+    wsMock.emit('close', {});
+
+    // At this point, the constructor should have been called only once.
+    assert(wsConstructor.calledOnce);
+
+    setTimeout(function() {
+      // Now the constructor should have been called twice
+      assert(wsConstructor.calledTwice);
+      done();
+    }, 15);
+  });
+
+  it('should reconnect only once when the connection fails rapidly', function(done) {
+    var ddpclient = new DDPClient({ auto_reconnect_timer: 5 });
+
+    ddpclient.connect();
+    wsMock.emit('close', {});
+    wsMock.emit('close', {});
+    wsMock.emit('close', {});
 
     // At this point, the constructor should have been called only once.
     assert(wsConstructor.calledOnce);


### PR DESCRIPTION
We were trying to reconnect on both error and close, which
when both were thrown, would start two reconnect attempts.
This was bad because each of the reconnect event would emit
both an error and a close event, which quickly went to an
exponentially infinite loop crashing my machine very very hard.

Now we have at most one reconnect timeout (which is cleared on
successful connection, for good measure), and we don't try
to reconnect on error.  faye-websocket provides the error
event purely for informational purposes; reconnection should
be attempted on close.
