### PR TITLE
Logging in successfully should always return a result, so the account info and auth token are available...

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,7 +42,7 @@ ddpclient.connect(function(error) {
   
   console.log('connected!');
   
-  ddpclient.loginWithUsername("myusername","ddp-rocks",function(err) {
+  ddpclient.loginWithUsername("myusername","ddp-rocks",function(err, result) {
       //Do stuff after login
   });
   

--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -279,7 +279,7 @@ DDPClient.prototype._login = function(loginParams, password, callback) {
       var conf = srp.verifyConfirmation({ HAMK : result.HAMK });
 
       if (conf) {
-        callback(null);
+        callback(null, result);
       } else {
         callback({error:"The HAMK doesn't match. Possible MITM attack"});
       }


### PR DESCRIPTION
The `login` method response, when successful, contains useful information about the account and notably, the authentication `token` value that can be later used to do a `resume` style login when re-establishing a connection to the server.

Presently for login methods that use the `_login` function, this result is only checked to verify the `HAMK` value, and then dropped. For the `loginWithToken` method, the result from the server response is returned as the second parameter to the provided callback.

This commit causes the result value to be passed back to the caller as a second parameter on the callback from the `_login` function as well, mirroring what is already done for `loginWithToken`.

There should be no security implications to making this login response easily accessible in this way, since the application can already listen for the appropriate `message` event on the client object to obtain the same information. This change simply makes it much easier to get the return value, and makes `loginWithToken` and all of the other methods use the same callback signature.

There are no backward compatibility issues with this update. It should be safe under semver for a x.x.+1 release.

Thanks for considering this change. I need it for my app to get access to the authentication token.

Vaughn
