### PR TITLE
Return the subscription ID

### DIFF
--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -329,6 +329,8 @@ DDPClient.prototype.subscribe = function(name, params, callback) {
     self._callbacks[id] = callback;
 
   self._send({msg: 'sub', id: id, name: name, params: params});
+
+  return id;
 };
 
 DDPClient.prototype.unsubscribe = function(id) {


### PR DESCRIPTION
Updated `subscribe` to return the new subscription ID.  This makes it _much_ easier to later `unsubscribe` from a subscription without having to also listen for the underlying message during the initial subscription.
