### PR TITLE
change error event to failed

### DIFF
--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -112,7 +112,7 @@ DDPClient.prototype._message = function(data) {
       self.connect();
     } else {
       self.auto_reconnect = false;
-      self.emit('error', 'cannot negotiate ddp version');
+      self.emit('failed', 'cannot negotiate ddp version');
     }
 
   } else if (data.msg === 'connected') {


### PR DESCRIPTION
`.connect()` callback handler looks for [`failed`](https://github.com/oortcloud/node-ddp-client/blob/9fc7b0f7d77a3ad7a778827462d906e1dcf00838/lib/ddp-client.js#L244) event. But we fire `error` event. 
This is the fix.
