### PR TITLE
Added 'new fields' to the changed observer

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -128,10 +128,11 @@ ddpclient.connect(function(error, wasReconnect) {
   observer.added = function(id) {
     console.log("[ADDED] to " + observer.name + ":  " + id);
   };
-  observer.changed = function(id, oldFields, clearedFields) {
+  observer.changed = function(id, oldFields, clearedFields, newFields) {
     console.log("[CHANGED] in " + observer.name + ":  " + id);
     console.log("[CHANGED] old field values: ", oldFields);
     console.log("[CHANGED] cleared fields: ", clearedFields);
+    console.log("[CHANGED] new fields: ", newFields);
   };
   observer.removed = function(id, oldValue) {
     console.log("[REMOVED] in " + observer.name + ":  " + id);

--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -210,11 +210,13 @@ DDPClient.prototype._message = function(data) {
       if (! self.collections[name][id]) { return; }
 
       var oldFields     = {},
-          clearedFields = data.cleared || [];
+          clearedFields = data.cleared || [],
+          newFields = {};
 
       if (data.fields) {
         _.each(data.fields, function(value, key) {
             oldFields[key] = self.collections[name][id][key];
+            newFields[key] = value;
             self.collections[name][id][key] = value;
         });
       }
@@ -227,7 +229,7 @@ DDPClient.prototype._message = function(data) {
 
       if (self._observers[name]) {
         _.each(self._observers[name], function(observer) {
-          observer.changed(id, oldFields, clearedFields);
+          observer.changed(id, oldFields, clearedFields, newFields);
         });
       }
     }

--- a/test/ddp-client.js
+++ b/test/ddp-client.js
@@ -177,8 +177,10 @@ describe('Collection maintenance and observation', function() {
   it('should response to "changed" messages', function() {
     var ddpclient = new DDPClient(), observed = false;
     observer = ddpclient.observe("posts");
-    observer.changed = function(id, oldFields, clearedFields) {
-      if (id === "2trpvcQ4pn32ZYXco" && oldFields.text === "A cat was here") {
+    observer.changed = function(id, oldFields, clearedFields, newFields) {
+      if (id === "2trpvcQ4pn32ZYXco"
+        && oldFields.text === "A cat was here"
+        && newFields.text === "A dog was here") {
         observed = true;
       }
     };


### PR DESCRIPTION
I found that also having access to what the new value of a collection property's object is can be helpful. I have added it to the end of the `changed` observer callback so that I don't break the existing API.

I have also extended the `changed` test to reflect the new callback arguments
