### PR TITLE
Remove connected and failed listeners on close

### DIFF
--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -310,6 +310,8 @@ DDPClient.prototype.close = function() {
   var self = this;
   self._isClosing = true;
   self.socket.close();
+  self.removeAllListeners("connected");
+  self.removeAllListeners("failed");
 };
 
 

--- a/test/ddp-client.js
+++ b/test/ddp-client.js
@@ -11,6 +11,7 @@ var wsConstructor, wsMock;
 
 function prepareMocks() {
   wsMock = new events.EventEmitter();
+  wsMock.close = sinon.stub();
 
   wsConstructor = sinon.stub();
   wsConstructor.returns(wsMock);
@@ -90,6 +91,21 @@ describe('Automatic reconnection', function() {
       done();
     }, 15);
   });
+
+  it('should clear event listeners on close', function(done) {
+    var ddpclient = new DDPClient();
+    var callback = sinon.stub();
+
+    ddpclient.connect(callback);
+    ddpclient.close();
+    ddpclient.connect(callback);
+
+    setTimeout(function() {
+      assert.equal(ddpclient.listeners('connected').length, 1);
+      assert.equal(ddpclient.listeners('failed').length, 1);
+      done();
+    }, 15);
+  })
 });
 
 


### PR DESCRIPTION
I noticed the `connected` and `failed` event listeners are not removed when connection is closed, causing them to pile up if connect/close cycle is called multiple times.

This fixes the issue by simply removing the listeners when `close()` is called.
