### PR TITLE
Handle socket errors occurring before connection is established

### DIFF
--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -40,6 +40,7 @@ var DDPClient = function(opts) {
   }
 
   // internal stuff to track callbacks
+  self._isConnecting = false;
   self._isReconnecting = false;
   self._nextId = 0;
   self._callbacks = {};
@@ -66,6 +67,11 @@ DDPClient.prototype._prepareHandlers = function() {
   });
 
   self.socket.on("error", function(error) {
+    // error received before connection was established
+    if (self._isConnecting) {
+      self.emit("failed", error.message);
+    }
+
     self.emit("socket-error", error);
   });
 
@@ -284,6 +290,7 @@ DDPClient.prototype._removeObserver = function(observer) {
  */
 DDPClient.prototype.connect = function(connected) {
   var self = this;
+  self._isConnecting = true;
   self._connectionFailed = false;
   self._isClosing = false;
 
@@ -292,9 +299,11 @@ DDPClient.prototype.connect = function(connected) {
       self._clearReconnectTimeout();
 
       connected(undefined, self._isReconnecting);
+      self._isConnecting = false;
       self._isReconnecting = false;
     });
     self.addListener("failed", function(error) {
+      self._isConnecting = false;
       self._connectionFailed = true;
       connected(error, self._isReconnecting);
     });


### PR DESCRIPTION
The callback function to `connect` is not called if a socket error occurs before the connection is established (eg. the server is down, connecting to wrong URL, etc).

Fixing the issue by emitting a `failed` event if a socket error occurs on the socket before receiving the `connected` message.

Also setting the initial value of `_isReconnecting` to `false` to make the first call to the connect callback consistent with the subsequent calls, and moving the event listener test to a more appropriate place.
