### PR TITLE
added tls options to be able to tune tls parameters (ca, cert, ...)

### DIFF
--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -25,6 +25,7 @@ var DDPClient = function(opts) {
   self.port = opts.port || 3000;
   self.path = opts.path;
   self.ssl  = opts.ssl  || self.port === 443;
+  self.tlsOpts = opts.tlsOpts || {};
   self.useSockJs = opts.useSockJs || false;
   self.autoReconnect = ("autoReconnect" in opts) ? opts.autoReconnect : true;
   self.autoReconnectTimer = ("autoReconnectTimer" in opts) ? opts.autoReconnectTimer : 500;
@@ -329,7 +330,8 @@ DDPClient.prototype._makeSockJSConnection = function() {
   var path = pathJoin("/", self.path || "", "sockjs/info");
   var url = protocol + self.host + ":" + self.port + path;
 
-  request.get(url, function(err, res, body) {
+  var requestOpts = {'url': url, 'agentOptions': self.tlsOpts}
+  request.get(requestOpts, function(err, res, body) {
     if (err) {
       self._recoverNetworkError();
     } else if (body) {
@@ -369,7 +371,7 @@ DDPClient.prototype._buildWsUrl = function(path) {
 
 DDPClient.prototype._makeWebSocketConnection = function(url) {
   var self = this;
-  self.socket = new WebSocket.Client(url);
+  self.socket = new WebSocket.Client(url, null, self.tlsOpts);
   self._prepareHandlers();
 };
 


### PR DESCRIPTION
This way, people are able to use self-signed certificate and make node-ddp-client still working when the correct tls options are povided