### PR TITLE
End pending method when connection drops

### DIFF
--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -48,8 +48,15 @@ var DDPClient = function(opts) {
   self._nextId = 0;
   self._callbacks = {};
   self._updatedCallbacks = {};
+  self._pendingMethods = {};
   self._observers = {};
 };
+
+
+DDPClient.ERRORS = {
+  DISCONNECTED: new Error("DDPClient: Disconnected from DDP server")
+};
+
 
 /**
  * Inherits from EventEmitter
@@ -80,6 +87,7 @@ DDPClient.prototype._prepareHandlers = function() {
 
   self.socket.on("close", function(event) {
     self.emit("socket-close", event.code, event.reason);
+    self._endPendingMethodCalls();
     self._recoverNetworkError();
   });
 
@@ -320,6 +328,24 @@ DDPClient.prototype.connect = function(connected) {
   }
 };
 
+DDPClient.prototype._endPendingMethodCalls = function() {
+  var self = this;
+  var ids = _.keys(self._pendingMethods);
+  self._pendingMethods = {};
+
+  ids.forEach(function (id) {
+    if(self._callbacks[id]) {
+      self._callbacks[id](DDPClient.ERRORS.DISCONNECTED);
+      delete self._callbacks[id];
+    }
+
+    if(self._updatedCallbacks[id]) {
+      self._updatedCallbacks[id]();
+      delete self._updatedCallbacks[id];
+    }
+  });
+};
+
 DDPClient.prototype._makeSockJSConnection = function() {
   var self = this;
 
@@ -389,13 +415,23 @@ DDPClient.prototype.call = function(name, params, callback, updatedCallback) {
   var self = this;
   var id = self._getNextId();
 
-  if (callback) {
-    self._callbacks[id] = callback;
-  }
+  self._callbacks[id] = function () {
+    delete self._pendingMethods[id];
 
-  if (updatedCallback) {
-    self._updatedCallbacks[id] = updatedCallback;
-  }
+    if (callback) {
+      callback.apply(this, arguments);
+    }
+  };
+
+  self._updatedCallbacks[id] = function () {
+    delete self._pendingMethods[id];
+
+    if (updatedCallback) {
+      updatedCallback.apply(this, arguments);
+    }
+  };
+
+  self._pendingMethods[id] = true;
 
   self._send({
     msg    : "method",


### PR DESCRIPTION
It'll be great if we can know the method we just called didn't complete. We can check whether the error returned is `DDPClient.ERRORS.DISCONNECTED` and maybe call the method again once the connection is ready.