### PR TITLE
Browserify-compatible

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -197,6 +197,10 @@ Meteor server uses SockJs to implement it's DDP server. With this mode, we can g
 
 > With this mode, `path` option has a special meaning. So, thing twice before using `path` option when you are using this option.
 
+Browser support
+====
+If your browser supports [WebSockets](http://caniuse.com/#feat=websockets), this DDP Client can be used in the browser too using [Browserify](http://browserify.org/), 
+
 Unimplemented Features
 ====
 The node DDP client does not implement ordered collections, something that while in the DDP spec has not been implemented in Meteor yet.

--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -2,7 +2,17 @@
 
 var util = require("util");
 var events = require("events");
-var WebSocket = require("faye-websocket");
+var WebSocket;
+
+var isBrowserified = (typeof window !== 'undefined');
+if (isBrowserified) {
+	window.WebSocket.prototype.on = function (event, callback) {
+		this['on' + event] = callback;
+	};
+} else {
+  var WebSocket = require("faye-websocket");
+}
+
 var EJSON = require("ddp-ejson");
 var request = require('request');
 var pathJoin = require('path').join;
@@ -402,7 +412,12 @@ DDPClient.prototype._buildWsUrl = function(path) {
 
 DDPClient.prototype._makeWebSocketConnection = function(url) {
   var self = this;
-  self.socket = new WebSocket.Client(url, null, self.tlsOpts);
+
+  if (isBrowserified) {
+    self.socket = new window.WebSocket(url);
+  } else {
+    self.socket = new WebSocket.Client(url, null, self.tlsOpts);
+  }
   self._prepareHandlers();
 };
 


### PR DESCRIPTION
Thank your for this, this stuff is awesome.

It can be used in the browser too! Browserify can be used to get it in the browser, but a minor tweak is needed. ```faye-websocket``` is not browserify-compatible and not needed since most modern browsers have WebSocket abilities themselves.

