### PR TITLE
Change setTimeout to setInterval

### DIFF
--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -110,7 +110,7 @@ DDPClient.prototype._recoverNetworkError = function() {
   var self = this;
   if (self.autoReconnect && ! self._connectionFailed && ! self._isClosing) {
     self._clearReconnectTimeout();
-    self.reconnectTimeout = setTimeout(function() { self.connect(); }, self.autoReconnectTimer);
+    self.reconnectTimeout = setInterval(function() { self.connect(); }, self.autoReconnectTimer);
     self._isReconnecting = true;
   }
 };


### PR DESCRIPTION
Change setTimeout to setInterval for consistent reconnection attempts.
Otherwise it just tries to reconnect once and if server was not online it just hangs forever doing nothing...