### PR TITLE
Fix adding changed handler on observer creator

### DIFF
--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -501,10 +501,10 @@ DDPClient.prototype.unsubscribe = function(id) {
 /**
  * Adds an observer to a collection and returns the observer.
  * Observation can be stopped by calling the stop() method on the observer.
- * Functions for added, updated and removed can be added to the observer
+ * Functions for added, changed and removed can be added to the observer
  * afterward.
  */
-DDPClient.prototype.observe = function(name, added, updated, removed) {
+DDPClient.prototype.observe = function(name, added, changed, removed) {
   var self = this;
   var observer = {};
   var id = self._getNextId();
@@ -518,7 +518,7 @@ DDPClient.prototype.observe = function(name, added, updated, removed) {
   Object.defineProperty(observer, "_id", { get: function() { return id; }});
 
   observer.added   = added   || function(){};
-  observer.updated = updated || function(){};
+  observer.changed = changed || function(){};
   observer.removed = removed || function(){};
 
   observer.stop = function() {


### PR DESCRIPTION
The DDP message parser is looking for an `observer.changed` function, but if you register a `changed` function via the `observe` function as the third argument, it gets registered as `updated` instead of `changed` and will throw when an update comes through.