### PR TITLE
Added try/catch for uncaught JSON parse error.

### DIFF
--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -362,8 +362,13 @@ DDPClient.prototype._makeSockJSConnection = function() {
     if (err) {
       self._recoverNetworkError();
     } else if (body) {
-      var info = JSON.parse(body);
-      if(!info.base_url) {
+      var info;
+      try {
+        info = JSON.parse(body);
+      } catch (e) {
+        console.error(e);
+      }
+      if (!info || !info.base_url) {
         // no base_url, then use pure WS handling
         var url = self._buildWsUrl();
         self._makeWebSocketConnection(url);


### PR DESCRIPTION
When Meteor.js is in development mode and your Meteor app crashes whilst your ddp-client is connected, the ddp-client will crash as well from an [uncaught JSON parsing error](https://github.com/oortcloud/unofficial-meteor-faq#uncaught-syntaxerror-unexpected-token-y). 

This crash only occurs when you are using ```sockJs: true```, ```autoReconnect: true``` or if you manually attempt to reconnect to the crashed website.  

The parsing error occurs due to Meteor sending a ddp message containing html to inform the client that their app is crashing e.g - ["Your app is crashing. Here's the latest log."](https://github.com/meteor/meteor/blob/f7b2735d2320eecafe478f3e4dd77ccaab848194/tools/runners/run-proxy.js#L203).   

I have kept the changes to a minimum, in order to not effect the code's structure. 

Let me know if you have any questions. @vsivsi 


