### PR TITLE
Call observer handlers even if maintainCollections is false

### DIFF
--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -179,8 +179,8 @@ DDPClient.prototype._message = function(data) {
 
   // add document to collection
   } else if (data.msg === "added") {
-    if (self.maintainCollections && data.collection) {
-      var name = data.collection, id = data.id;
+    var name = data.collection, id = data.id;
+    if (self.maintainCollections && name) {
 
       if (! self.collections[name])     { self.collections[name] = {}; }
       if (! self.collections[name][id]) { self.collections[name][id] = {}; }
@@ -192,32 +192,33 @@ DDPClient.prototype._message = function(data) {
           self.collections[name][id][key] = value;
         });
       }
-
-      if (self._observers[name]) {
-        _.each(self._observers[name], function(observer) {
-          observer.added(id);
-        });
-      }
+    }
+    
+    if (self._observers[name]) {
+      _.each(self._observers[name], function(observer) {
+        observer.added(id, data.fields);
+      });
     }
 
   // remove document from collection
   } else if (data.msg === "removed") {
+    var name = data.collection, id = data.id;
+    var oldValue = undefined;
+    
     if (self.maintainCollections && data.collection) {
-      var name = data.collection, id = data.id;
-
       if (! self.collections[name][id]) {
         return;
       }
 
-      var oldValue = self.collections[name][id];
+      oldValue = self.collections[name][id];
 
       delete self.collections[name][id];
-
-      if (self._observers[name]) {
-        _.each(self._observers[name], function(observer) {
-          observer.removed(id, oldValue);
-        });
-      }
+    }
+    
+    if (self._observers[name]) {
+      _.each(self._observers[name], function(observer) {
+        observer.removed(id, oldValue);
+      });
     }
 
   // change document in collection
@@ -249,6 +250,13 @@ DDPClient.prototype._message = function(data) {
       if (self._observers[name]) {
         _.each(self._observers[name], function(observer) {
           observer.changed(id, oldFields, clearedFields, newFields);
+        });
+      }
+    } else if (data.collection) {
+      var name = data.collection, id = data.id;
+      if (self._observers[name]) {
+        _.each(self._observers[name], function(observer) {
+          observer.changed(id, data.fields, data.cleared || []);
         });
       }
     }

--- a/test/ddp-client.js
+++ b/test/ddp-client.js
@@ -299,6 +299,25 @@ describe('Collection maintenance and observation', function() {
     assert.equal(ddpclient.collections.posts['2trpvcQ4pn32ZYXco'].text, "A cat was here");
     assert.equal(ddpclient.collections.posts['2trpvcQ4pn32ZYXco'].value, true);
   });
+  
+  it('should response to "added" with fields even if maintainCollections is false', function() {
+    var ddpclient = new DDPClient({ maintainCollections: false }), observed = false;
+    var addedFields = undefined;
+    observer = ddpclient.observe("posts");
+    observer.added = function(id, fields) {
+      if (id === '2trpvcQ4pn32ZYXco') {
+        observed = true;
+        addedFields = fields;
+      }
+    }
+
+    ddpclient._message(addedMessage);
+    // ensure there are no collections
+    assert(!ddpclient.collections);
+    assert(observed, "addition observed");
+    assert.equal(addedFields.text, "A cat was here");
+    assert.equal(addedFields.value, true);
+  });
 
   it('should response to "changed" messages', function() {
     var ddpclient = new DDPClient(), observed = false;
@@ -334,6 +353,28 @@ describe('Collection maintenance and observation', function() {
     assert(!ddpclient.collections.posts['2trpvcQ4pn32ZYXco'].hasOwnProperty('value'));
     assert(observed, "cleared change observed")
   });
+  
+  it('should response to "changed" even if maintainCollections is false', function() {
+    var ddpclient = new DDPClient({ maintainCollections: false }), observed = false;
+    observer = ddpclient.observe("posts");
+    observer.changed = function(id, fields) {
+      if (id === "2trpvcQ4pn32ZYXco" && fields.text === "A dog was here") {
+        observed = true;
+      }
+    };
+
+    ddpclient._message(addedMessage);
+    
+    // ensure there are no collections
+    assert(!ddpclient.collections);
+    
+    ddpclient._message(changedMessage);
+    
+    // ensure there are no collections
+    assert(!ddpclient.collections);
+    
+    assert(observed, "field change observed");
+  });
 
   it('should response to "removed" messages', function() {
     var ddpclient = new DDPClient(), oldval;
@@ -346,6 +387,24 @@ describe('Collection maintenance and observation', function() {
     assert(oldval, "Removal observed");
     assert.equal(oldval.text, "A cat was here");
     assert.equal(oldval.value, true);
+  });
+  
+  it('should response to "removed" even if maintainCollections is false', function() {
+    var ddpclient = new DDPClient({ maintainCollections: false }), docid;
+    observer = ddpclient.observe("posts");
+    observer.removed = function(id) { docid = id; };
+
+    ddpclient._message(addedMessage);
+    
+    // ensure there are no collections
+    assert(!ddpclient.collections);
+    
+    ddpclient._message(removedMessage);
+    
+    // ensure there are no collections
+    assert(!ddpclient.collections);
+    
+    assert.equal(docid, "2trpvcQ4pn32ZYXco");
   });
 });
 


### PR DESCRIPTION
This allows app to observe events without keeping them in memory.