### PR TITLE
Correctly update internal connection status

### DIFF
--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -146,6 +146,8 @@ DDPClient.prototype._message = function(data) {
 
   } else if (data.msg === "connected") {
     self.session = data.session;
+    self._isConnecting = false;
+    self._isReconnecting = false;
     self.emit("connected");
 
   // method result


### PR DESCRIPTION
The function argument to `client.connect()` is meant to be optional.

However, unless you pass a function argument, the internal
booleans `_isConnecting` and `_isReconnecting` never get updated.

This PR correctly updates the booleans to `false` when a `connected` message is received from the server.