### PR TITLE
Fix ignored sends when server is disconnected

### DIFF
--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -118,9 +118,13 @@ DDPClient.prototype._recoverNetworkError = function() {
 ///////////////////////////////////////////////////////////////////////////
 // RAW, low level functions
 DDPClient.prototype._send = function(data) {
-  this.socket.send(
-    EJSON.stringify(data)
-  );
+  if (message !== 'connect' && this._isConnecting) {
+    this._endPendingMethodCalls()
+  } else {
+    this.socket.send(
+      EJSON.stringify(data)
+    );
+  }
 };
 
 // handle a message from the server


### PR DESCRIPTION
When the server is offline, a ddpclient.send would effectivley be
ignored. The callbacks would still be registered, and the messages are
lost. The behavior is described in more detail here vsivsi/meteor-job-collection#203.

This patch makes send requests callback with errors if the server is
not connected. There is a small exception to the "connect" message,
which obviously shouldn't be blocked.