### PR TITLE
Fix: vulnerability in request dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ddp-underscore-patched": "0.8.1-2",
     "ddp-ejson": "0.8.1-3",
     "faye-websocket": "0.11.0",
-    "request": "2.79.0"
+    "request": "2.87.0"
   },
   "devDependencies": {
     "mocha": "~3.2.0",


### PR DESCRIPTION
request@2.74.0 has a dependency of tunnel-agent@0.4.1, which has a reported vulnerability (see https://nodesecurity.io/advisories/598).

This PR upgrades the dependency of request to latest, in which tunnel-agent also have been fixed.