### PR TITLE
Add proxy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.12.2 - 2018-07-12
+
+  - Update npm dependencies, including request, to fix yet another vulnerablility
+  - Add option to pass proxy configuration to websocket
+
 0.12.1 — 2016-09-15
 
   - Update npm dependencies, including request, to fix vulnerability (#89)

--- a/README.markdown
+++ b/README.markdown
@@ -58,7 +58,12 @@ var ddpclient = new DDPClient({
   useSockJs: true,
   // Use a full url instead of a set of `host`, `port` and `ssl`
   // do not set `useSockJs` option if `url` is used
-  url: 'wss://example.com/websocket'
+  url: 'wss://example.com/websocket',
+  // The contents of `proxyOpts` are passed to the underlying
+  // Websocket client.
+  proxyOpts: {
+    origin: 'http://username:password@proxy.example.com'
+  }
 });
 
 /*

--- a/examples/example.js
+++ b/examples/example.js
@@ -2,9 +2,9 @@
 
 var DDPClient = require("../lib/ddp-client");
 
-var ddpclient = new DDPClient({
+var ddpclientOpts = {
   // All properties optional, defaults shown
-  host : "localhost",
+  host : process.env.host || "localhost",
   port : 3000,
   ssl  : false,
   autoReconnect : true,
@@ -20,7 +20,16 @@ var ddpclient = new DDPClient({
   // Use a full url instead of a set of `host`, `port` and `ssl`
   // do not set `useSockJs` option if `url` is used
   url: 'wss://example.com/websocket'
-});
+};
+
+if (process.env.proxy_origin) {
+  console.log("Using proxy:", process.env.proxy_origin);
+  ddpclientOpts.proxyOpts = {
+    origin: process.env.proxy_origin
+  }
+}
+
+var ddpclient = new DDPClient(ddpclientOpts);
 
 /*
  * Connect to the Meteor Server
@@ -29,7 +38,7 @@ ddpclient.connect(function(error, wasReconnect) {
   // If autoReconnect is true, this callback will be invoked each time
   // a server connection is re-established
   if (error) {
-    console.log("DDP connection error!");
+    console.log("DDP connection error!", error);
     return;
   }
 

--- a/lib/ddp-client.js
+++ b/lib/ddp-client.js
@@ -25,7 +25,8 @@ var DDPClient = function(opts) {
   self.port = opts.port || 3000;
   self.path = opts.path;
   self.ssl  = opts.ssl  || self.port === 443;
-  self.tlsOpts = opts.tlsOpts || {};
+  self.tlsOpts = opts.tlsOpts;
+  self.proxyOpts = opts.proxyOpts;
   self.useSockJs = opts.useSockJs || false;
   self.autoReconnect = ("autoReconnect" in opts) ? opts.autoReconnect : true;
   self.autoReconnectTimer = ("autoReconnectTimer" in opts) ? opts.autoReconnectTimer : 500;
@@ -411,7 +412,14 @@ DDPClient.prototype._buildWsUrl = function(path) {
 
 DDPClient.prototype._makeWebSocketConnection = function(url) {
   var self = this;
-  self.socket = new WebSocket.Client(url, null, self.tlsOpts);
+  var options = {};
+  if (self.tlsOpts) {
+    options.tls = self.tlsOpts;
+  }
+  if (self.proxyOpts) {
+    options.proxy = self.proxyOpts;
+  }
+  self.socket = new WebSocket.Client(url, null, options);
   self._prepareHandlers();
 };
 

--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
     "url": "https://github.com/oortcloud/node-ddp-client.git"
   },
   "dependencies": {
-    "ddp-underscore-patched": "0.8.1-2",
     "ddp-ejson": "0.8.1-3",
+    "ddp-underscore-patched": "0.8.1-2",
     "faye-websocket": "0.11.0",
-    "request": "2.74.x"
+    "request": "^2.87.0"
   },
   "devDependencies": {
-    "mocha": "~3.0.2",
+    "mocha": "^5.2.0",
     "sinon": "~1.17.5",
     "rewire": "~2.5.2"
   },

--- a/test/ddp-client.js
+++ b/test/ddp-client.js
@@ -51,9 +51,30 @@ describe("Connect to remote server", function() {
   it('should propagate tls options if specified', function() {
     var tlsOpts = {
       'ca': ['fake_pem_content']
-    }
+    };
     new DDPClient({'host': 'myserver.com', 'port': 443, 'tlsOpts': tlsOpts}).connect();
-    assert.deepEqual(wsConstructor.args, [['wss://myserver.com:443/websocket', null, tlsOpts]]);
+    assert.deepEqual(wsConstructor.args, [['wss://myserver.com:443/websocket', null, { tls: tlsOpts }]]);
+  });
+
+  it('should propagate proxy options if specified', function() {
+    var proxyOpts = {
+      origin: 'http://username:password@proxy.example.com',
+      headers: {'User-Agent': 'node'}
+    };
+    new DDPClient({'host': 'myserver.com', 'port': 443, 'proxyOpts': proxyOpts}).connect();
+    assert.deepEqual(wsConstructor.args, [['wss://myserver.com:443/websocket', null, { proxy: proxyOpts }]]);
+  });
+
+  it('should propagate both tls and proxy options if specified', function() {
+    var tlsOpts = {
+      'ca': ['fake_pem_content']
+    };
+    var proxyOpts = {
+      origin: 'http://username:password@proxy.example.com',
+      headers: {'User-Agent': 'node'}
+    };
+    new DDPClient({'host': 'myserver.com', 'port': 443, 'tlsOpts': tlsOpts, 'proxyOpts': proxyOpts}).connect();
+    assert.deepEqual(wsConstructor.args, [['wss://myserver.com:443/websocket', null, { tls: tlsOpts, proxy: proxyOpts }]]);
   });
 
   it('should connect to the provided url', function() {


### PR DESCRIPTION
This PR enables the user of `DDPClient` to pass options for connecting through a proxy server to the underlying WebSocket implementation.

- Includes tests (all pass)
- Includes updated Readme
- Includes updated example

Additionally, I've updated some dependencies based on security reports of `npm audit`.

I have run a basic manual test with a transparent squid proxy.