### PR TITLE
Update dep request to avoid deprecated sub deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ddp-underscore-patched": "0.8.1-2",
     "ddp-ejson": "0.8.1-3",
     "faye-websocket": "0.11.0",
-    "request": "2.74.x"
+    "request": "2.88.x"
   },
   "devDependencies": {
     "mocha": "~3.0.2",


### PR DESCRIPTION
request 2.74.x uses deprecated versions of a number of packages causing warnings when installing node-ddp-client. Update request to latest.

Unit tests still run without error.
